### PR TITLE
feature/resource logs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,6 @@
 
     <Description>A standalone resouce server for .NET Aspire</Description>
 
-    <Version>0.0.1</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Todo
 
 - [x] Standalone resource server
-- [ ] Collecting external containers' logs
+- [x] Collecting external containers' logs
 - [ ] Handling commands to external containers
 
 ## Test environment (manual)

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -25,7 +25,7 @@ services:
   aspire_dashboard:
     image: mcr.microsoft.com/dotnet/aspire-dashboard:8.2
     environment:
-      DASHBOARD__FRONTEND__AUTHMODE: "Unsecured"
+      # DASHBOARD__FRONTEND__AUTHMODE: "Unsecured"
       DASHBOARD__RESOURCESERVICECLIENT__URL: "http://host.docker.internal:7007"
       DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE: "Unsecured"
     ports:

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -3,14 +3,12 @@ version: '3.8'
 services:
   redis:
     image: redis:latest
-    container_name: dev_redis
     ports:
       - "6379:6379"
     networks:
       - dev_network
   rabbitmq:
     image: rabbitmq:management
-    container_name: dev_rabbitmq
     ports:
       - "5672:5672"
       - "15672:15672"
@@ -18,7 +16,6 @@ services:
       - dev_network
   mongodb:
     image: mongo:latest
-    container_name: dev_mongodb
     ports:
       - "27017:27017"
     volumes:
@@ -31,7 +28,6 @@ services:
       DASHBOARD__FRONTEND__AUTHMODE: "Unsecured"
       DASHBOARD__RESOURCESERVICECLIENT__URL: "http://host.docker.internal:7007"
       DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE: "Unsecured"
-    container_name: dev_aspire_dashboard
     ports:
       - "18888:18888"
       - "4317:18889"

--- a/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
@@ -42,8 +42,8 @@ internal sealed partial class DockerResourceProvider : IResourceProvider
                 .Select(s => new Url
                 {
                     IsInternal = false,
-                    Name = $"https://{s.IP}:{s.PublicPort}",
-                    FullUrl = $"https://{s.IP}:{s.PublicPort}"
+                    Name = $"http://{s.IP}:{s.PublicPort}",
+                    FullUrl = $"http://{s.IP}:{s.PublicPort}"
                 }));
 
             resources.Add(ar);

--- a/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/IResourceProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/IResourceProvider.cs
@@ -4,5 +4,6 @@ namespace Aspire.ResourceService.Standalone.Server.ResourceProviders;
 
 internal interface IResourceProvider
 {
+    IAsyncEnumerable<string> GerResourceLogs(string resourceName, CancellationToken cancellationToken);
     Task<List<Resource>> GetResourcesAsync();
 }

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
@@ -14,7 +14,7 @@ public sealed class ServiceInformationTests
         IServiceInformationProvider sut = new AssemblyServiceInformationProvider();
 
 
-        sut.GetServiceInformation().Version.Should().Be("0.0.1");
+        sut.GetServiceInformation().Version.Should().Be("0.2.0");
         sut.GetServiceInformation().Name.Should().Be("Aspire.ResourceService.Standalone.Server");
     }
 


### PR DESCRIPTION
- **Bump version to 0.2.0**
  This feature intruduces a new unimplemented feature - the resource log
  monitoring.
  

- **[WIP] Basic container log implementation**
  This implementation only is a PoC that we can capture container logs using the
  Docker.DotNet library and stream them to the dashboard
  

- **Update expected version in VersionGuard test**
  The version assertion in the `VersionGuard` test method of the
  `ServiceInformationTests` class has been updated. Previously, the
  test expected the version to be "0.0.1", but it has now been changed
  to expect the version to be "0.2.0". This change reflects the
  incremented version of the service information.
  

- **Introduce caching for Docker container listings**
  Add a caching mechanism in the `DockerResourceProvider`
  to improve performance by storing Docker container listings.
  

- **Remove container_name from docker compose file**
  The container_name property has been removed from the redis, rabbitmq, mongodb,
  and services sections in the compose.yaml file. Docker will now automatically
  generate container names for these services instead of using the specified names.
  This change helps avoid potential naming conflicts and makes the Docker setup more flexible.
  

- **Remove dev_network and comment out AUTHMODE env var**
  The `DASHBOARD__FRONTEND__AUTHMODE` environment variable,
  previously set to "Unsecured", has been commented out. This
  indicates that the authentication mode for the frontend is no
  longer explicitly set to "Unsecured" and may be using a different
  configuration or default value.
  

- **Change URL scheme from https to http in ar.Urls**
  Updated the URL scheme from `https` to `http` for the URLs being added
  to aspire resources to comply with the default scheme used in Docker Desktop
  client.
  Ports exposed from contnainers are 'generally' HTTP port anyway.
  

- **Add resouce log watching to DockerResourceProvider**
  This implementation uses an `IProgress` fed from the Docker.DotNet client
  when asking it to "follow" a container's logs and writes those information
  in a local unbound channel. This channel is then asynchronously read and
  the values (the log entries) are returned.
  

- **Update README.md**
  Mark the container log collection as done
  