### PR TITLE
tests/resource provider tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,6 @@
 
     <Description>A standalone resouce server for .NET Aspire</Description>
 
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
 </Project>

--- a/src/Aspire.ResourceService.Standalone.Server/AspireModels/KnownProperties.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/AspireModels/KnownProperties.cs
@@ -1,6 +1,8 @@
 // Copied from and inspired by .NET Aspire's KnownProperties.cs
 // https://github.com/dotnet/aspire/blob/main/src/Shared/Model/KnownProperties.cs
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Dashboard.Model;
 
 /// <summary>
@@ -10,6 +12,7 @@ namespace Aspire.Dashboard.Model;
 /// Used as keys in the "properties" dictionary on resource snapshots and view models.
 /// Should be compared using <see cref="StringComparer.Ordinal"/>.
 /// </remarks>
+[ExcludeFromCodeCoverage]
 internal static class KnownProperties
 {
     public static class Resource

--- a/src/Aspire.ResourceService.Standalone.Server/AspireModels/KnownResourceTypes.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/AspireModels/KnownResourceTypes.cs
@@ -1,8 +1,11 @@
 // Copied from and inspired by .NET Aspire's KnownResourceTypes.cs
 // https://github.com/dotnet/aspire/blob/main/src/Shared/Model/KnownResourceTypes.cs
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Dashboard.Model;
 
+[ExcludeFromCodeCoverage]
 internal static class KnownResourceTypes
 {
     public const string Container = "Container";

--- a/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
@@ -95,7 +95,7 @@ internal sealed partial class DockerResourceProvider : IResourceProvider
         {
             await _syncRoot.WaitAsync();
             var c = await _dockerClient.Containers
-                .ListContainersAsync(new ContainersListParameters())
+                .ListContainersAsync(new ContainersListParameters(), CancellationToken.None)
                 .ConfigureAwait(false);
 
             _dockerContainers.AddRange(c);

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/DockerResourceProviderTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/DockerResourceProviderTests.cs
@@ -1,0 +1,144 @@
+﻿using Aspire.ResourceService.Standalone.Server.ResourceProviders;
+
+using Docker.DotNet;
+using Docker.DotNet.Models;
+
+using FluentAssertions;
+
+using Google.Protobuf.WellKnownTypes;
+
+using Moq;
+
+namespace Aspire.ResourceService.Standalone.Server.Tests.ResourceProvider;
+public class DockerResourceProviderTests : IDisposable
+{
+    private readonly Mock<IDockerClient> _dockerClientMock;
+    private readonly DockerResourceProvider _dockerResourceProvider;
+
+    public DockerResourceProviderTests()
+    {
+        _dockerClientMock = new Mock<IDockerClient>();
+        _dockerResourceProvider = new DockerResourceProvider(_dockerClientMock.Object);
+    }
+
+    [Fact]
+    public async Task GetResourcesAsyncShouldReturnResources()
+    {
+        // Arrange
+        var containers = new List<ContainerListResponse>
+        {
+            new() {
+                ID = "1",
+                Names = ["container1"],
+                State = "running",
+                Created = DateTime.UtcNow,
+                Ports = [new() { IP = "127.0.0.1", PublicPort = 80 }]
+            }
+        };
+
+        _dockerClientMock.Setup(c => c.Containers.ListContainersAsync(It.IsAny<ContainersListParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(containers);
+
+        // Act
+        var resources = await _dockerResourceProvider.GetResourcesAsync();
+
+        // Assert
+        resources.Should().HaveCount(1);
+        var resource = resources.First();
+        resource.Uid.Should().Be("1");
+        resource.Name.Should().Be("container1");
+        resource.State.Should().Be("running");
+        resource.CreatedAt.Should().Be(Timestamp.FromDateTime(containers[0].Created));
+        resource.Urls.Should().ContainSingle(url => url.FullUrl == "http://127.0.0.1:80");
+    }
+
+    [Fact]
+    public async Task GettingContainersHitsTheCacheAfterFirstTime()
+    {
+        // Arrange
+        var containers = new List<ContainerListResponse>
+        {
+            new() {
+                ID = "1",
+                Names = ["container1"],
+                State = "running",
+                Created = DateTime.UtcNow,
+                Ports = [new() { IP = "127.0.0.1", PublicPort = 80 }]
+            }
+        };
+
+        _dockerClientMock.Setup(c => c.Containers.ListContainersAsync(It.IsAny<ContainersListParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(containers);
+
+        // Act
+        for (var i = 0; i < 10; i++)
+        {
+            _ = await _dockerResourceProvider.GetResourcesAsync();
+        }
+
+        // Assert
+        _dockerClientMock.Verify(c => c.Containers.ListContainersAsync(It.IsAny<ContainersListParameters>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+
+    [Fact]
+    public async Task GerResourceLogsShouldReturnLogs()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromSeconds(2));
+
+        var containers = new List<ContainerListResponse>
+        {
+            new() {
+                ID = "1",
+                Names = ["container1"]
+            }
+        };
+
+        _dockerClientMock.Setup(c => c.Containers.ListContainersAsync(It.IsAny<ContainersListParameters>(), CancellationToken.None))
+            .ReturnsAsync(containers);
+
+        var logs = new List<string> { "log1", "log2" };
+
+        _dockerClientMock
+            .Setup(c => c.Containers.GetContainerLogsAsync(
+                It.IsAny<string>(),
+                It.IsAny<ContainerLogsParameters>(),
+                cts.Token,
+                It.IsAny<IProgress<string>>()))
+            .Callback<string, ContainerLogsParameters, CancellationToken, IProgress<string>>((id, parameters, token, progress) =>
+            {
+                foreach (var log in logs)
+                {
+                    progress.Report(log);
+                }
+            })
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var resultLogs = new List<string>();
+        try
+        {
+            await foreach (var log in _dockerResourceProvider.GerResourceLogs("container1", cts.Token).ConfigureAwait(false))
+            {
+                resultLogs.Add(log);
+            }
+        }
+        catch (Exception ex) when (ex is TaskCanceledException or OperationCanceledException)
+        {
+            // cts.Task is cancelled mimicking the end of the log stream.
+            // Swallow
+        }
+
+
+        // Assert
+        resultLogs.Should().BeEquivalentTo(logs);
+    }
+
+    public void Dispose()
+    {
+        _dockerResourceProvider?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/ServiceCollectionExtensionsTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,44 @@
+﻿using Aspire.ResourceService.Standalone.Server.ResourceProviders;
+
+using Docker.DotNet;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+
+namespace Aspire.ResourceService.Standalone.Server.Tests.ResourceProvider;
+
+public class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddResourceProviderShouldRegisterDockerClient()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddResourceProvider();
+        var serviceProvider = services.BuildServiceProvider();
+        var dockerClient = serviceProvider.GetService<IDockerClient>();
+
+        // Assert
+        dockerClient.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddResourceProviderShouldRegisterResourceProvider()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddResourceProvider();
+        var serviceProvider = services.BuildServiceProvider();
+        var resourceProvider = serviceProvider.GetService<IResourceProvider>();
+
+        // Assert
+        resourceProvider.Should().NotBeNull();
+        resourceProvider.Should().BeOfType<DockerResourceProvider>();
+    }
+}


### PR DESCRIPTION
- **Add ExcludeFromCodeCoverage to Aspire classes**
  Two classes `KnownProperties.cs` and `KnownResourceTypes.cs` are copied
  from the .NET Aspire project and dont need test coverage in this project.
  

- **Bump patch version**
  From 0.2.0 to 0.2.1
  

- **Add tests for resource privider DI registrations**
  

- **Update docker container caching and cancellation**
  In docker resource provider we assume that the library
  can successfully and eventually get a list of
  running containers so we use the static
  `CancellationToken.None` in the method call to get all
  containers from the docker runtime.
  

- **Add tests for docker resource provider**
  