### PR TITLE
feature/observability

### DIFF
--- a/Aspire.ResourceService.Standalone.sln
+++ b/Aspire.ResourceService.Standalone.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.ResourceService.Stan
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.ResourceService.Standalone.Server.Tests", "tests\Aspire.ResourceService.Standalone.Server.Tests\Aspire.ResourceService.Standalone.Server.Tests.csproj", "{7C5F1EEC-6E23-4B3B-936D-135FEB241F31}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.ResourceService.Standalone.ServiceDefaults", "src\Aspire.ResourceService.Standalone.ServiceDefaults\Aspire.ResourceService.Standalone.ServiceDefaults.csproj", "{3F33BD73-FB51-4516-8D76-50D573533F5C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{7C5F1EEC-6E23-4B3B-936D-135FEB241F31}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C5F1EEC-6E23-4B3B-936D-135FEB241F31}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C5F1EEC-6E23-4B3B-936D-135FEB241F31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F33BD73-FB51-4516-8D76-50D573533F5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F33BD73-FB51-4516-8D76-50D573533F5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F33BD73-FB51-4516-8D76-50D573533F5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F33BD73-FB51-4516-8D76-50D573533F5C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,5 +59,6 @@ Global
 		{814C273E-ECD0-492E-9F97-494DF8352023} = {6E405F73-722B-43F6-808E-4CB16FA3ADB0}
 		{20984F03-BA2E-404D-A15D-6A763BCDBBAA} = {6E405F73-722B-43F6-808E-4CB16FA3ADB0}
 		{7C5F1EEC-6E23-4B3B-936D-135FEB241F31} = {E5A71AF7-6E1E-45D9-B686-68D23454F7FF}
+		{3F33BD73-FB51-4516-8D76-50D573533F5C} = {6E405F73-722B-43F6-808E-4CB16FA3ADB0}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,6 @@
 
     <Description>A standalone resouce server for .NET Aspire</Description>
 
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
 </Project>

--- a/src/Aspire.ResourceService.Standalone.Server/Aspire.ResourceService.Standalone.Server.csproj
+++ b/src/Aspire.ResourceService.Standalone.Server/Aspire.ResourceService.Standalone.Server.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.66.0" />
-    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.66.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.67.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.ResourceService.Standalone.Server/Aspire.ResourceService.Standalone.Server.csproj
+++ b/src/Aspire.ResourceService.Standalone.Server/Aspire.ResourceService.Standalone.Server.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.67.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Aspire.ResourceService.Standalone.ServiceDefaults\Aspire.ResourceService.Standalone.ServiceDefaults.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Aspire.ResourceService.Standalone.Server/Program.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Program.cs
@@ -22,10 +22,9 @@ if (app.Environment.IsDevelopment())
     app.MapGrpcReflectionService();
 }
 
-app.MapGrpcService<DashboardService>();
-
 app.MapDefaultEndpoints();
 app.MapGet("/info", (IServiceInformationProvider sip) => Results.Ok(sip.GetServiceInformation()));
 
+app.MapGrpcService<DashboardService>();
 
 app.Run();

--- a/src/Aspire.ResourceService.Standalone.Server/Program.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Program.cs
@@ -4,6 +4,8 @@ using Aspire.ResourceService.Standalone.Server.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddServiceDefaults();
+
 // Add services to the container.
 builder.Services.AddServiceInformationProvider();
 builder.Services.AddResourceProvider();
@@ -22,6 +24,7 @@ if (app.Environment.IsDevelopment())
 
 app.MapGrpcService<DashboardService>();
 
+app.MapDefaultEndpoints();
 app.MapGet("/info", (IServiceInformationProvider sip) => Results.Ok(sip.GetServiceInformation()));
 
 

--- a/src/Aspire.ResourceService.Standalone.Server/appsettings.json
+++ b/src/Aspire.ResourceService.Standalone.Server/appsettings.json
@@ -10,5 +10,6 @@
     "EndpointDefaults": {
       "Protocols": "Http2"
     }
-  }
+  },
+  "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"
 }

--- a/src/Aspire.ResourceService.Standalone.ServiceDefaults/Aspire.ResourceService.Standalone.ServiceDefaults.csproj
+++ b/src/Aspire.ResourceService.Standalone.ServiceDefaults/Aspire.ResourceService.Standalone.ServiceDefaults.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.10.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
   </ItemGroup>
 

--- a/src/Aspire.ResourceService.Standalone.ServiceDefaults/Aspire.ResourceService.Standalone.ServiceDefaults.csproj
+++ b/src/Aspire.ResourceService.Standalone.ServiceDefaults/Aspire.ResourceService.Standalone.ServiceDefaults.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aspire.ResourceService.Standalone.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ResourceService.Standalone.ServiceDefaults/Extensions.cs
@@ -54,7 +54,8 @@ public static class Extensions
             .WithMetrics(metrics => metrics
                 .AddAspNetCoreInstrumentation()
                 .AddHttpClientInstrumentation()
-                .AddRuntimeInstrumentation())
+                .AddRuntimeInstrumentation()
+                .AddProcessInstrumentation())
             .WithTracing(tracing => tracing
                 .AddAspNetCoreInstrumentation()
                 .AddGrpcClientInstrumentation()

--- a/src/Aspire.ResourceService.Standalone.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ResourceService.Standalone.ServiceDefaults/Extensions.cs
@@ -1,0 +1,119 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+// ReSharper disable CheckNamespace
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddAspNetCoreInstrumentation()
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    .AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks("/health");
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/src/Aspire.ResourceService.Standalone.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ResourceService.Standalone.ServiceDefaults/Extensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
@@ -16,6 +17,8 @@ namespace Microsoft.Extensions.Hosting;
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
+    private const string ServiceName = "Aspire.ResourceService.Standalone.Server";
+    private static readonly string ServiceVersion = typeof(Extensions).Assembly.GetName().Version?.ToString(3) ?? "-";
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
     {
         builder.ConfigureOpenTelemetry();
@@ -46,11 +49,16 @@ public static class Extensions
     {
         builder.Logging.AddOpenTelemetry(logging =>
         {
+            logging.SetResourceBuilder(ResourceBuilder.CreateDefault()
+                .AddService(ServiceName, serviceVersion: ServiceVersion));
+
             logging.IncludeFormattedMessage = true;
             logging.IncludeScopes = true;
         });
 
         builder.Services.AddOpenTelemetry()
+            .ConfigureResource(rb => rb
+                .AddService(ServiceName, serviceVersion: ServiceVersion))
             .WithMetrics(metrics => metrics
                 .AddAspNetCoreInstrumentation()
                 .AddHttpClientInstrumentation()

--- a/src/Aspire.ResourceService.Standalone.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ResourceService.Standalone.ServiceDefaults/Extensions.cs
@@ -3,12 +3,12 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.ServiceDiscovery;
+
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-// ReSharper disable CheckNamespace
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace Microsoft.Extensions.Hosting;
 
 // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
@@ -51,19 +51,14 @@ public static class Extensions
         });
 
         builder.Services.AddOpenTelemetry()
-            .WithMetrics(metrics =>
-            {
-                metrics.AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
-            })
-            .WithTracing(tracing =>
-            {
-                tracing.AddAspNetCoreInstrumentation()
-                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
-                    .AddGrpcClientInstrumentation()
-                    .AddHttpClientInstrumentation();
-            });
+            .WithMetrics(metrics => metrics
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddRuntimeInstrumentation())
+            .WithTracing(tracing => tracing
+                .AddAspNetCoreInstrumentation()
+                .AddGrpcClientInstrumentation()
+                .AddHttpClientInstrumentation());
 
         builder.AddOpenTelemetryExporters();
 
@@ -117,3 +112,5 @@ public static class Extensions
         return app;
     }
 }
+
+#pragma warning restore IDE0130 // Namespace does not match folder structure

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/Aspire.ResourceService.Standalone.Server.Tests.csproj
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/Aspire.ResourceService.Standalone.Server.Tests.csproj
@@ -8,12 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
@@ -14,7 +14,7 @@ public sealed class ServiceInformationTests
         IServiceInformationProvider sut = new AssemblyServiceInformationProvider();
 
 
-        sut.GetServiceInformation().Version.Should().Be("0.2.1");
+        sut.GetServiceInformation().Version.Should().Be("0.3.0");
         sut.GetServiceInformation().Name.Should().Be("Aspire.ResourceService.Standalone.Server");
     }
 


### PR DESCRIPTION
- **Add Aspire's `ServiceDefaults` project.**
  The project is used to facilitiate OpenTelemetry instrumentation and
  other utilities like resiliency.
  

- **Update nuget packages**
  

- **Add reference to ServiceDefaults project**
  

- **Add service defaults and default endpoints**
  The Service Defaults is defined in the ServiceDefaults project and sets up
  OpenTelemetry and other general stuff
  
  The default endpoints are for liveness and readiness
  

- **chore: code cleanup**
  

- **Update version**
  The version is bumped from `0.2.1` to `0.3.0` which represents a minor feature.
  In this version the standalone server instruments observability signals
  including logs,traces and metric complying with the OpenTelemetry standards.
  

- **Move grpc service mapping after the REST endpoints.**
  

- **Install process instrumentation**
  Add `OpenTelemetry.Instrumentation.Process` package
  and add the metric instrumentation helper
  

- **Add resource definitions to logs, metrics and traces**
  

- **Point the server telemetry to the standalone dashboard**
  