### PR TITLE
editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,6 @@ indent_style = space
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-spelling_exclusion_path = spelling.dic
 
 [*.cs]
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -330,10 +330,6 @@ dotnet_diagnostic.IDE0060.severity = warning
 # IDE0062: Make local function static
 dotnet_diagnostic.IDE0062.severity = warning
 
-# IDE0073: File header
-dotnet_diagnostic.IDE0073.severity = warning
-file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
-
 # IDE1006: Required naming style
 dotnet_diagnostic.IDE1006.severity = warning
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -23,84 +23,6 @@ insert_final_newline = true
 indent_size = 4
 dotnet_sort_system_directives_first = true
 
-# Don't use this. qualifier
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-
-# use int x = .. over Int32
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-
-# use int.MaxValue over Int32.MaxValue
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-# Require var all the time.
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
-
-# Disallow throw expressions.
-csharp_style_throw_expression = false:suggestion
-
-# Newline settings
-csharp_new_line_before_open_brace = all
-csharp_new_line_before_else = true
-csharp_new_line_before_catch = true
-csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_object_initializers = true
-csharp_new_line_before_members_in_anonymous_types = true
-
-# Namespace settings
-csharp_style_namespace_declarations = file_scoped
-
-# Brace settings
-csharp_prefer_braces = true # Prefer curly braces even for one line of code
-
-# name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds   = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-
-# static fields should have s_ prefix
-dotnet_naming_rule.static_fields_should_have_prefix.severity = warning
-dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
-dotnet_naming_symbols.static_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-dotnet_naming_style.static_prefix_style.required_prefix = s_
-dotnet_naming_style.static_prefix_style.capitalization = camel_case
-
-# internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
-
-[*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
-indent_size = 2
-
-# Xml config files
-[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
-indent_size = 2
-
-[*.json]
-indent_size = 2
-
-[*.{ps1,psm1}]
-indent_size = 4
-
-[*.sh]
-indent_size = 4
-end_of_line = lf
-
-[*.{cs,vb}]
-
 # SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 dotnet_diagnostic.SYSLIB1054.severity = warning
 
@@ -301,7 +223,7 @@ dotnet_diagnostic.IDE0031.severity = warning
 dotnet_diagnostic.IDE0035.severity = warning
 
 # IDE0036: Order modifiers
-csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+csharp_preferred_modifier_order = public, private, protected, internal, file, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
 dotnet_diagnostic.IDE0036.severity = warning
 
 # IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
@@ -343,3 +265,79 @@ dotnet_style_allow_multiple_blank_lines_experimental = false
 dotnet_diagnostic.IDE2000.severity = warning
 
 dotnet_diagnostic.ASPIREEVENTING001.severity = none
+
+# Don't use this. qualifier
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+# use int x = .. over Int32
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+# use int.MaxValue over Int32.MaxValue
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Require var all the time.
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Disallow throw expressions.
+csharp_style_throw_expression = false:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+
+# Namespace settings
+csharp_style_namespace_declarations = file_scoped
+
+# Brace settings
+csharp_prefer_braces = true # Prefer curly braces even for one line of code
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = warning
+dotnet_naming_rule.static_fields_should_have_prefix.symbols = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+[*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.{ps1,psm1}]
+indent_size = 4
+
+[*.sh]
+indent_size = 4
+end_of_line = lf

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,390 +1,350 @@
+; EditorConfig to support per-solution formatting.
+; Use the EditorConfig VS add-in to make this work.
+; http://editorconfig.org/
+;
+; Here are some resources for what's supported for .NET/C#
+; https://kent-boogaart.com/blog/editorconfig-reference-for-c-developers
+; https://learn.microsoft.com/visualstudio/ide/editorconfig-code-style-settings-reference
+;
+; Be **careful** editing this because some of the rules don't support adding a severity level
+; For instance if you change to `dotnet_sort_system_directives_first = true:warning` (adding `:warning`)
+; then the rule will be silently ignored.
+
+; This is the default for the codeline.
 root = true
 
-# All files
 [*]
 indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+spelling_exclusion_path = spelling.dic
 
-# Xml files
-[*.xml]
+[*.cs]
+indent_size = 4
+dotnet_sort_system_directives_first = true
+
+# Don't use this. qualifier
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+# use int x = .. over Int32
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+# use int.MaxValue over Int32.MaxValue
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Require var all the time.
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Disallow throw expressions.
+csharp_style_throw_expression = false:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+
+# Namespace settings
+csharp_style_namespace_declarations = file_scoped
+
+# Brace settings
+csharp_prefer_braces = true # Prefer curly braces even for one line of code
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = warning
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+[*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
 indent_size = 2
 
-# C# files
-[*.cs]
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
 
-#### Core EditorConfig Options ####
+[*.json]
+indent_size = 2
 
-# Indentation and spacing
+[*.{ps1,psm1}]
 indent_size = 4
-tab_width = 4
 
-# New line preferences
-insert_final_newline = false
+[*.sh]
+indent_size = 4
+end_of_line = lf
 
-#### .NET Coding Conventions ####
 [*.{cs,vb}]
 
-# Organize usings
-dotnet_separate_import_directive_groups = true
-dotnet_sort_system_directives_first = true
-file_header_template = unset
-
-# this. and Me. preferences
-dotnet_style_qualification_for_event = false:silent
-dotnet_style_qualification_for_field = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_property = false:silent
-
-# Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true:silent
-dotnet_style_predefined_type_for_member_access = true:silent
-
-# Parentheses preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
-
-# Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
-
-# Expression-level preferences
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_namespace_match_folder = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
-dotnet_style_prefer_conditional_expression_over_return = true:suggestion
-dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
-dotnet_style_prefer_simplified_interpolation = true:suggestion
-
-# Field preferences
-dotnet_style_readonly_field = true:warning
-
-# Parameter preferences
-dotnet_code_quality_unused_parameters = all:suggestion
-
-# Suppression preferences
-dotnet_remove_unnecessary_suppression_exclusions = none
-
-#### C# Coding Conventions ####
-[*.cs]
-
-# var preferences
-csharp_style_var_elsewhere = true:silent
-csharp_style_var_for_built_in_types = true:silent
-csharp_style_var_when_type_is_apparent = true:silent
-
-# Expression-bodied members
-csharp_style_expression_bodied_accessors = false:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_indexers = false:silent
-csharp_style_expression_bodied_lambdas = true:suggestion
-csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_properties = false:silent
-
-# Pattern matching preferences
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_prefer_extended_property_pattern = true:suggestion
-csharp_style_prefer_not_pattern = true:suggestion
-csharp_style_prefer_pattern_matching = true:silent
-csharp_style_prefer_switch_expression = true:suggestion
-
-# Null-checking preferences
-csharp_style_conditional_delegate_call = true:suggestion
-
-# Modifier preferences
-csharp_prefer_static_anonymous_function = true:suggestion
-csharp_prefer_static_local_function = true:warning
-csharp_preferred_modifier_order = public, private, protected, internal, file, const, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, required, volatile, async:suggestion
-csharp_style_prefer_readonly_struct = true:suggestion
-csharp_style_prefer_readonly_struct_member = true:suggestion
-
-# Code-block preferences
-csharp_prefer_braces = true:silent
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_style_namespace_declarations = file_scoped:suggestion
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_primary_constructors = false
-csharp_style_prefer_top_level_statements = true:silent
-
-# Expression-level preferences
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_style_prefer_null_check_over_type_check = true:suggestion
-csharp_style_prefer_range_operator = true:suggestion
-csharp_style_prefer_tuple_swap = true:suggestion
-csharp_style_prefer_utf8_string_literals = true:suggestion
-csharp_style_throw_expression = true:suggestion
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-
-# 'using' directive preferences
-csharp_using_directive_placement = outside_namespace:silent
-
-#### C# Formatting Rules ####
-
-# New line preferences
-csharp_new_line_before_catch = true
-csharp_new_line_before_else = true
-csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_members_in_object_initializers = true
-csharp_new_line_before_open_brace = all
-csharp_new_line_between_query_expression_clauses = true
-
-# Indentation preferences
-csharp_indent_block_contents = true
-csharp_indent_braces = false
-csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
-csharp_indent_labels = one_less_than_current
-csharp_indent_switch_labels = true
-
-# Space preferences
-csharp_space_after_cast = false
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_after_comma = true
-csharp_space_after_dot = false
-csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_after_semicolon_in_for_statement = true
-csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = false
-csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_before_comma = false
-csharp_space_before_dot = false
-csharp_space_before_open_square_brackets = false
-csharp_space_before_semicolon_in_for_statement = false
-csharp_space_between_empty_square_brackets = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_declaration_name_and_open_parenthesis = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = false
-csharp_space_between_square_brackets = false
-
-# Wrapping preferences
-csharp_preserve_single_line_blocks = true
-csharp_preserve_single_line_statements = true
-csharp_prefer_system_threading_lock = true:suggestion
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
-csharp_style_allow_embedded_statements_on_same_line_experimental = false:silent
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
-csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
-csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
-
-#### Naming styles ####
-[*.{cs,vb}]
-
-# Naming rules
-
-dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols = types_and_namespaces
-dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
-dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols = interfaces
-dotnet_naming_rule.interfaces_should_be_ipascalcase.style = ipascalcase
-
-dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = suggestion
-dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols = type_parameters
-dotnet_naming_rule.type_parameters_should_be_tpascalcase.style = tpascalcase
-
-dotnet_naming_rule.methods_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.methods_should_be_pascalcase.symbols = methods
-dotnet_naming_rule.methods_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.properties_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.properties_should_be_pascalcase.symbols = properties
-dotnet_naming_rule.properties_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.events_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.events_should_be_pascalcase.symbols = events
-dotnet_naming_rule.events_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.local_variables_should_be_camelcase.severity = suggestion
-dotnet_naming_rule.local_variables_should_be_camelcase.symbols = local_variables
-dotnet_naming_rule.local_variables_should_be_camelcase.style = camelcase
-
-dotnet_naming_rule.local_constants_should_be_camelcase.severity = suggestion
-dotnet_naming_rule.local_constants_should_be_camelcase.symbols = local_constants
-dotnet_naming_rule.local_constants_should_be_camelcase.style = camelcase
-
-dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
-dotnet_naming_rule.parameters_should_be_camelcase.symbols = parameters
-dotnet_naming_rule.parameters_should_be_camelcase.style = camelcase
-
-dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.public_fields_should_be_pascalcase.symbols = public_fields
-dotnet_naming_rule.public_fields_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
-dotnet_naming_rule.private_fields_should_be__camelcase.symbols = private_fields
-dotnet_naming_rule.private_fields_should_be__camelcase.style = _camelcase
-
-dotnet_naming_rule.private_static_fields_should_be_s_camelcase.severity = suggestion
-dotnet_naming_rule.private_static_fields_should_be_s_camelcase.symbols = private_static_fields
-dotnet_naming_rule.private_static_fields_should_be_s_camelcase.style = s_camelcase
-
-dotnet_naming_rule.public_constant_fields_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.public_constant_fields_should_be_pascalcase.symbols = public_constant_fields
-dotnet_naming_rule.public_constant_fields_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.private_constant_fields_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.private_constant_fields_should_be_pascalcase.symbols = private_constant_fields
-dotnet_naming_rule.private_constant_fields_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.symbols = public_static_readonly_fields
-dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.symbols = private_static_readonly_fields
-dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.enums_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.enums_should_be_pascalcase.symbols = enums
-dotnet_naming_rule.enums_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.local_functions_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.local_functions_should_be_pascalcase.symbols = local_functions
-dotnet_naming_rule.local_functions_should_be_pascalcase.style = pascalcase
-
-dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
-
-# Symbol specifications
-
-dotnet_naming_symbols.interfaces.applicable_kinds = interface
-dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interfaces.required_modifiers =
-
-dotnet_naming_symbols.enums.applicable_kinds = enum
-dotnet_naming_symbols.enums.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.enums.required_modifiers =
-
-dotnet_naming_symbols.events.applicable_kinds = event
-dotnet_naming_symbols.events.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.events.required_modifiers =
-
-dotnet_naming_symbols.methods.applicable_kinds = method
-dotnet_naming_symbols.methods.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.methods.required_modifiers =
-
-dotnet_naming_symbols.properties.applicable_kinds = property
-dotnet_naming_symbols.properties.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.properties.required_modifiers =
-
-dotnet_naming_symbols.public_fields.applicable_kinds = field
-dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
-dotnet_naming_symbols.public_fields.required_modifiers =
-
-dotnet_naming_symbols.private_fields.applicable_kinds = field
-dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
-dotnet_naming_symbols.private_fields.required_modifiers =
-
-dotnet_naming_symbols.private_static_fields.applicable_kinds = field
-dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
-dotnet_naming_symbols.private_static_fields.required_modifiers = static
-
-dotnet_naming_symbols.types_and_namespaces.applicable_kinds = namespace, class, struct, interface, enum
-dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types_and_namespaces.required_modifiers =
-
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers =
-
-dotnet_naming_symbols.type_parameters.applicable_kinds = namespace
-dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
-dotnet_naming_symbols.type_parameters.required_modifiers =
-
-dotnet_naming_symbols.private_constant_fields.applicable_kinds = field
-dotnet_naming_symbols.private_constant_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
-dotnet_naming_symbols.private_constant_fields.required_modifiers = const
-
-dotnet_naming_symbols.local_variables.applicable_kinds = local
-dotnet_naming_symbols.local_variables.applicable_accessibilities = local
-dotnet_naming_symbols.local_variables.required_modifiers =
-
-dotnet_naming_symbols.local_constants.applicable_kinds = local
-dotnet_naming_symbols.local_constants.applicable_accessibilities = local
-dotnet_naming_symbols.local_constants.required_modifiers = const
-
-dotnet_naming_symbols.parameters.applicable_kinds = parameter
-dotnet_naming_symbols.parameters.applicable_accessibilities = *
-dotnet_naming_symbols.parameters.required_modifiers =
-
-dotnet_naming_symbols.public_constant_fields.applicable_kinds = field
-dotnet_naming_symbols.public_constant_fields.applicable_accessibilities = public, internal
-dotnet_naming_symbols.public_constant_fields.required_modifiers = const
-
-dotnet_naming_symbols.public_static_readonly_fields.applicable_kinds = field
-dotnet_naming_symbols.public_static_readonly_fields.applicable_accessibilities = public, internal
-dotnet_naming_symbols.public_static_readonly_fields.required_modifiers = readonly, static
-
-dotnet_naming_symbols.private_static_readonly_fields.applicable_kinds = field
-dotnet_naming_symbols.private_static_readonly_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
-dotnet_naming_symbols.private_static_readonly_fields.required_modifiers = readonly, static
-
-dotnet_naming_symbols.local_functions.applicable_kinds = local_function
-dotnet_naming_symbols.local_functions.applicable_accessibilities = *
-dotnet_naming_symbols.local_functions.required_modifiers =
-
-# Naming styles
-
-dotnet_naming_style.pascalcase.required_prefix =
-dotnet_naming_style.pascalcase.required_suffix =
-dotnet_naming_style.pascalcase.word_separator =
-dotnet_naming_style.pascalcase.capitalization = pascal_case
-
-dotnet_naming_style.ipascalcase.required_prefix = I
-dotnet_naming_style.ipascalcase.required_suffix =
-dotnet_naming_style.ipascalcase.word_separator =
-dotnet_naming_style.ipascalcase.capitalization = pascal_case
-
-dotnet_naming_style.tpascalcase.required_prefix = T
-dotnet_naming_style.tpascalcase.required_suffix =
-dotnet_naming_style.tpascalcase.word_separator =
-dotnet_naming_style.tpascalcase.capitalization = pascal_case
-
-dotnet_naming_style._camelcase.required_prefix = _
-dotnet_naming_style._camelcase.required_suffix =
-dotnet_naming_style._camelcase.word_separator =
-dotnet_naming_style._camelcase.capitalization = camel_case
-
-dotnet_naming_style.camelcase.required_prefix =
-dotnet_naming_style.camelcase.required_suffix =
-dotnet_naming_style.camelcase.word_separator =
-dotnet_naming_style.camelcase.capitalization = camel_case
-
-dotnet_naming_style.s_camelcase.required_prefix = s_
-dotnet_naming_style.s_camelcase.required_suffix =
-dotnet_naming_style.s_camelcase.word_separator =
-dotnet_naming_style.s_camelcase.capitalization = camel_case
-tab_width = 4
-indent_size = 4
-end_of_line = crlf
-dotnet_style_allow_statement_immediately_after_block_experimental = false:silent
-dotnet_style_allow_multiple_blank_lines_experimental = true:silent
-insert_final_newline = true
+# SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+dotnet_diagnostic.SYSLIB1054.severity = warning
 
+# CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1018.severity = warning
+
+# CA1047: Do not declare protected member in sealed type
+dotnet_diagnostic.CA1047.severity = warning
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = warning
+
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = warning
+
+# CA1510: Use ArgumentNullException throw helper
+dotnet_diagnostic.CA1510.severity = warning
+
+# CA1511: Use ArgumentException throw helper
+dotnet_diagnostic.CA1511.severity = warning
+
+# CA1512: Use ArgumentOutOfRangeException throw helper
+dotnet_diagnostic.CA1512.severity = warning
+
+# CA1513: Use ObjectDisposedException throw helper
+dotnet_diagnostic.CA1513.severity = warning
+
+# CA1725: Parameter names should match base declaration
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA1802: Use literals where appropriate
+dotnet_diagnostic.CA1802.severity = warning
+
+# CA1805: Do not initialize unnecessarily
+dotnet_diagnostic.CA1805.severity = warning
+
+# CA1810: Do not initialize unnecessarily
+dotnet_diagnostic.CA1810.severity = warning
+
+# CA1821: Remove empty Finalizers
+dotnet_diagnostic.CA1821.severity = warning
+
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = warning
+dotnet_code_quality.CA1822.api_surface = private, internal
+
+# CA1823: Avoid unused private fields
+dotnet_diagnostic.CA1823.severity = warning
+
+# CA1825: Avoid zero-length array allocations
+dotnet_diagnostic.CA1825.severity = warning
+
+# CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
+dotnet_diagnostic.CA1826.severity = warning
+
+# CA1827: Do not use Count() or LongCount() when Any() can be used
+dotnet_diagnostic.CA1827.severity = warning
+
+# CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+dotnet_diagnostic.CA1828.severity = warning
+
+# CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1829.severity = warning
+
+# CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+dotnet_diagnostic.CA1830.severity = warning
+
+# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1831.severity = warning
+
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1832.severity = warning
+
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1833.severity = warning
+
+# CA1834: Consider using 'StringBuilder.Append(char)' when applicable
+dotnet_diagnostic.CA1834.severity = warning
+
+# CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+dotnet_diagnostic.CA1835.severity = warning
+
+# CA1836: Prefer IsEmpty over Count
+dotnet_diagnostic.CA1836.severity = warning
+
+# CA1837: Use 'Environment.ProcessId'
+dotnet_diagnostic.CA1837.severity = warning
+
+# CA1838: Avoid 'StringBuilder' parameters for P/Invokes
+dotnet_diagnostic.CA1838.severity = warning
+
+# CA1839: Use 'Environment.ProcessPath'
+dotnet_diagnostic.CA1839.severity = warning
+
+# CA1840: Use 'Environment.CurrentManagedThreadId'
+dotnet_diagnostic.CA1840.severity = warning
+
+# CA1841: Prefer Dictionary.Contains methods
+dotnet_diagnostic.CA1841.severity = warning
+
+# CA1842: Do not use 'WhenAll' with a single task
+dotnet_diagnostic.CA1842.severity = warning
+
+# CA1843: Do not use 'WaitAll' with a single task
+dotnet_diagnostic.CA1843.severity = warning
+
+# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
+dotnet_diagnostic.CA1844.severity = warning
+
+# CA1845: Use span-based 'string.Concat'
+dotnet_diagnostic.CA1845.severity = warning
+
+# CA1846: Prefer AsSpan over Substring
+dotnet_diagnostic.CA1846.severity = warning
+
+# CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
+dotnet_diagnostic.CA1847.severity = warning
+
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = warning
+
+# CA1854: Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+dotnet_diagnostic.CA1854.severity = warning
+
+# CA1855: Prefer 'Clear' over 'Fill'
+dotnet_diagnostic.CA1855.severity = warning
+
+# CA1856: Incorrect usage of ConstantExpected attribute
+dotnet_diagnostic.CA1856.severity = error
+
+# CA1857: A constant is expected for the parameter
+dotnet_diagnostic.CA1857.severity = warning
+
+# CA1858: Use 'StartsWith' instead of 'IndexOf'
+dotnet_diagnostic.CA1858.severity = warning
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = warning
+
+# CA2008: Do not create tasks without passing a TaskScheduler
+dotnet_diagnostic.CA2008.severity = warning
+
+# CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+dotnet_diagnostic.CA2009.severity = warning
+
+# CA2011: Avoid infinite recursion
+dotnet_diagnostic.CA2011.severity = warning
+
+# CA2012: Use ValueTask correctly
+dotnet_diagnostic.CA2012.severity = warning
+
+# CA2013: Do not use ReferenceEquals with value types
+dotnet_diagnostic.CA2013.severity = warning
+
+# CA2014: Do not use stackalloc in loops.
+dotnet_diagnostic.CA2014.severity = warning
+
+# CA2016: Forward the 'CancellationToken' parameter to methods that take one
+dotnet_diagnostic.CA2016.severity = warning
+
+# CA2200: Rethrow to preserve stack details
+dotnet_diagnostic.CA2200.severity = warning
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = warning
+
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = warning
+
+# CA2245: Do not assign a property to itself
+dotnet_diagnostic.CA2245.severity = warning
+
+# CA2246: Assigning symbol and its member in the same statement
+dotnet_diagnostic.CA2246.severity = warning
+
+# CA2249: Use string.Contains instead of string.IndexOf to improve readability.
+dotnet_diagnostic.CA2249.severity = warning
+
+# IDE0005: Remove unnecessary usings
+dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0011: Curly braces to surround blocks of code
+dotnet_diagnostic.IDE0011.severity = warning
+
+# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
+dotnet_diagnostic.IDE0020.severity = warning
+
+# IDE0029: Use coalesce expression (non-nullable types)
+dotnet_diagnostic.IDE0029.severity = warning
+
+# IDE0030: Use coalesce expression (nullable types)
+dotnet_diagnostic.IDE0030.severity = warning
+
+# IDE0031: Use null propagation
+dotnet_diagnostic.IDE0031.severity = warning
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
+dotnet_diagnostic.IDE0038.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0051: Remove unused private members
+dotnet_diagnostic.IDE0051.severity = warning
+
+# IDE0055: All formatting rules
+dotnet_diagnostic.IDE0055.severity = suggestion
+
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
+
+# IDE0060: Remove unused parameter
+dotnet_code_quality_unused_parameters = non_public
+dotnet_diagnostic.IDE0060.severity = warning
+
+# IDE0062: Make local function static
+dotnet_diagnostic.IDE0062.severity = warning
+
+# IDE0073: File header
+dotnet_diagnostic.IDE0073.severity = warning
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
+
+# IDE1006: Required naming style
+dotnet_diagnostic.IDE1006.severity = warning
+
+# IDE0161: Convert to file-scoped namespace
+dotnet_diagnostic.IDE0161.severity = warning
+
+# IDE0200: Lambda expression can be removed
+dotnet_diagnostic.IDE0200.severity = warning
+
+# IDE2000: Disallow multiple blank lines
+dotnet_style_allow_multiple_blank_lines_experimental = false
+dotnet_diagnostic.IDE2000.severity = warning
+
+dotnet_diagnostic.ASPIREEVENTING001.severity = none

--- a/src/Aspire.ResourceService.Standalone.Server/Diagnostics/AssemblyServiceInformationProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Diagnostics/AssemblyServiceInformationProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspire.ResourceService.Standalone.Server.Diagnostics;
+namespace Aspire.ResourceService.Standalone.Server.Diagnostics;
 
 internal sealed class AssemblyServiceInformationProvider : IServiceInformationProvider
 {

--- a/src/Aspire.ResourceService.Standalone.Server/Diagnostics/Constants.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Diagnostics/Constants.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspire.ResourceService.Standalone.Server.Diagnostics;
+namespace Aspire.ResourceService.Standalone.Server.Diagnostics;
 
 internal static class Constants
 {

--- a/src/Aspire.ResourceService.Standalone.Server/Diagnostics/IServiceInformationProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Diagnostics/IServiceInformationProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspire.ResourceService.Standalone.Server.Diagnostics;
+namespace Aspire.ResourceService.Standalone.Server.Diagnostics;
 
 public interface IServiceInformationProvider
 {

--- a/src/Aspire.ResourceService.Standalone.Server/Diagnostics/ServerDiagnostics.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Diagnostics/ServerDiagnostics.cs
@@ -5,14 +5,9 @@ namespace Aspire.ResourceService.Standalone.Server.Diagnostics;
 
 internal static class ServerDiagnostics
 {
-    private static readonly Assembly Assembly = typeof(AssemblyServiceInformationProvider).Assembly;
+    private static readonly Assembly s_assembly = typeof(AssemblyServiceInformationProvider).Assembly;
 
-    public static readonly string ServiceVersion;
+    public static readonly string ServiceVersion = s_assembly.GetName().Version?.ToString(3) ?? "0.0.0";
 
     public static ActivitySource ServerActivitySource = new(Constants.ServiceName, ServiceVersion);
-
-    static ServerDiagnostics()
-    {
-        ServiceVersion = Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
-    }
 }

--- a/src/Aspire.ResourceService.Standalone.Server/Diagnostics/ServerDiagnostics.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Diagnostics/ServerDiagnostics.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace Aspire.ResourceService.Standalone.Server.Diagnostics;

--- a/src/Aspire.ResourceService.Standalone.Server/Diagnostics/ServiceCollectionExtensions.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Diagnostics/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Aspire.ResourceService.Standalone.Server.Diagnostics;
 

--- a/src/Aspire.ResourceService.Standalone.Server/GlobalSuppressions.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/Aspire.ResourceService.Standalone.Server/Program.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Program.cs
@@ -13,9 +13,7 @@ builder.Services.AddResourceProvider();
 builder.Services.AddGrpc();
 builder.Services.AddGrpcReflection();
 
-
 var app = builder.Build();
-
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/Aspire.ResourceService.Standalone.Server/Properties/AssemblyAttributes.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Properties/AssemblyAttributes.cs
@@ -1,3 +1,3 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Aspire.ResourceService.Standalone.Server.Tests")]

--- a/src/Aspire.ResourceService.Standalone.Server/Properties/AssemblyAttributes.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Properties/AssemblyAttributes.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Aspire.ResourceService.Standalone.Server.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
@@ -66,7 +66,6 @@ internal sealed partial class DockerResourceProvider : IResourceProvider
             notificationChannel.Writer.TryWrite(log);
         }
 
-
         IProgress<string> p = new Progress<string>(WriteToChannel);
 
         _ = _dockerClient.Containers
@@ -93,7 +92,7 @@ internal sealed partial class DockerResourceProvider : IResourceProvider
 
         try
         {
-            await _syncRoot.WaitAsync();
+            await _syncRoot.WaitAsync().ConfigureAwait(false);
             var c = await _dockerClient.Containers
                 .ListContainersAsync(new ContainersListParameters(), CancellationToken.None)
                 .ConfigureAwait(false);

--- a/src/Aspire.ResourceService.Standalone.Server/Services/DashboardService.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Services/DashboardService.cs
@@ -86,7 +86,7 @@ internal sealed class DashboardService : Proto.V1.DashboardService.DashboardServ
         {
             try
             {
-                await foreach (var log in _resourceProvider.GerResourceLogs(request.ResourceName, cts.Token))
+                await foreach (var log in _resourceProvider.GerResourceLogs(request.ResourceName, cts.Token).ConfigureAwait(false))
                 {
                     update.LogLines.Add(new ConsoleLogLine { Text = log, IsStdErr = false, LineNumber = ++lineNumber });
                     await responseStream.WriteAsync(update, cts.Token).ConfigureAwait(false);
@@ -130,7 +130,6 @@ internal static partial class WatchResourcesLogs
 
     [LoggerMessage(Events.InitialResourcesSent, LogLevel.Trace, "Initial resources sent")]
     public static partial void InitialResourcesWroteToStreamSuccessfully(this ILogger logger);
-
 
     [LoggerMessage(Events.ErrorWatchingResources, LogLevel.Error, "Error executing service method {Method}")]
     public static partial void LogErrorWatchingResources(this ILogger logger, string method, Exception ex);

--- a/src/Aspire.ResourceService.Standalone.Server/Services/DashboardService.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Services/DashboardService.cs
@@ -54,7 +54,7 @@ internal sealed class DashboardService : Proto.V1.DashboardService.DashboardServ
 
             _logger.WritingInitialResourcesToStream();
             await responseStream
-                .WriteAsync(new WatchResourcesUpdate { InitialData = data }, cts.Token)
+                .WriteAsync(new WatchResourcesUpdate { InitialData = data }, CancellationToken.None)
                 .ConfigureAwait(false);
             _logger.InitialResourcesWroteToStreamSuccessfully();
 
@@ -89,7 +89,7 @@ internal sealed class DashboardService : Proto.V1.DashboardService.DashboardServ
                 await foreach (var log in _resourceProvider.GerResourceLogs(request.ResourceName, cts.Token).ConfigureAwait(false))
                 {
                     update.LogLines.Add(new ConsoleLogLine { Text = log, IsStdErr = false, LineNumber = ++lineNumber });
-                    await responseStream.WriteAsync(update, cts.Token).ConfigureAwait(false);
+                    await responseStream.WriteAsync(update, CancellationToken.None).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/DashboardService/DashboardServiceTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/DashboardService/DashboardServiceTests.cs
@@ -1,0 +1,128 @@
+using Aspire.ResourceService.Proto.V1;
+using Aspire.ResourceService.Standalone.Server.Diagnostics;
+using Aspire.ResourceService.Standalone.Server.ResourceProviders;
+using Aspire.ResourceService.Standalone.Server.Tests.Helpers;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using DashboardServiceImpl = Aspire.ResourceService.Standalone.Server.Services.DashboardService;
+
+namespace Aspire.ResourceService.Standalone.Server.Tests.DashboardService;
+
+public class DashboardServiceTests
+{
+    private readonly Mock<IServiceInformationProvider> _mockServiceInformationProvider;
+    private readonly Mock<IResourceProvider> _mockResourceProvider;
+    private readonly Mock<IHostApplicationLifetime> _mockHostApplicationLifetime;
+    private readonly DashboardServiceImpl _dashboardService;
+
+    public DashboardServiceTests()
+    {
+        _mockServiceInformationProvider = new Mock<IServiceInformationProvider>();
+        _mockResourceProvider = new Mock<IResourceProvider>();
+        _mockHostApplicationLifetime = new Mock<IHostApplicationLifetime>();
+        _dashboardService = new DashboardServiceImpl(
+            _mockServiceInformationProvider.Object,
+            _mockResourceProvider.Object,
+            _mockHostApplicationLifetime.Object,
+            NullLogger<DashboardServiceImpl>.Instance);
+    }
+
+    [Fact]
+    public async Task GetApplicationInformationTest()
+    {
+        // Arrange
+        var expectedName = Constants.ServiceName;
+        _mockServiceInformationProvider
+            .Setup(x => x.GetServiceInformation())
+            .Returns(new ServiceInformation { Name = expectedName });
+
+        var request = new ApplicationInformationRequest();
+        var context = TestServerCallContext.Create();
+
+        // Act
+        var response = await _dashboardService.GetApplicationInformation(request, context).ConfigureAwait(false);
+
+        // Assert
+        response.ApplicationName.Should().Be(expectedName);
+    }
+
+    [Fact]
+    public async Task WatchResourcesStreamsData()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        var callContext = TestServerCallContext.Create(cancellationToken: cts.Token);
+        var responseStream = new TestServerStreamWriter<WatchResourcesUpdate>(callContext);
+
+        var resources = new List<Resource> { new() };
+        _mockResourceProvider
+            .Setup(x => x.GetResourcesAsync())
+            .ReturnsAsync(resources);
+
+        // Act
+        using var call = _dashboardService.WatchResources(new WatchResourcesRequest { IsReconnect = true }, responseStream, callContext);
+
+        // Assert
+        call.IsCompleted.Should().BeTrue();
+        await call.ConfigureAwait(false);
+        responseStream.Complete();
+
+        var allMessages = new List<WatchResourcesUpdate>();
+        await foreach (var message in responseStream.ReadAllAsync().ConfigureAwait(false))
+        {
+            allMessages.Add(message);
+        }
+
+        allMessages.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task WatchResourcesLogs()
+    {
+        // Arrange
+        var logs = new List<string> { "Log1", "Log2" };
+        _mockResourceProvider
+            .Setup(x => x.GerResourceLogs(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(logs.ToAsyncEnumerable());
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        var callContext = TestServerCallContext.Create(cancellationToken: cts.Token);
+        var responseStream = new TestServerStreamWriter<WatchResourceConsoleLogsUpdate>(callContext);
+
+        var request = new WatchResourceConsoleLogsRequest { ResourceName = "resource" };
+
+        // Act
+        var call = _dashboardService.WatchResourceConsoleLogs(request, responseStream, callContext);
+
+        call.IsCompleted.Should().BeTrue();
+        await call.ConfigureAwait(false);
+
+        responseStream.Complete();
+
+        // Assert
+        var update = await responseStream.ReadNextAsync().ConfigureAwait(false);
+        update.Should().NotBeNull();
+        update!.LogLines.Should().HaveCount(2);
+        update.LogLines[0].Text.Should().Be(logs[0]);
+        update.LogLines[1].Text.Should().Be(logs[1]);
+    }
+
+}
+
+internal static class Extensions
+{
+    internal static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IEnumerable<T> enumerable)
+    {
+        foreach (var item in enumerable)
+        {
+            yield return item;
+        }
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+}

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
@@ -1,4 +1,4 @@
-﻿using Aspire.ResourceService.Standalone.Server.Diagnostics;
+using Aspire.ResourceService.Standalone.Server.Diagnostics;
 
 using FluentAssertions;
 
@@ -12,7 +12,6 @@ public sealed class ServiceInformationTests
     public void VersionGuard()
     {
         IServiceInformationProvider sut = new AssemblyServiceInformationProvider();
-
 
         sut.GetServiceInformation().Version.Should().Be("0.3.0");
         sut.GetServiceInformation().Name.Should().Be("Aspire.ResourceService.Standalone.Server");
@@ -61,7 +60,6 @@ public sealed class ServiceInformationTests
         si.Name.Should().Be("mock-name");
         si.Version.Should().Be("mock-version");
     }
-
 
     private sealed class MockServiceInformationProvider : IServiceInformationProvider
     {

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/Helpers/TestAsyncStreamReader.ofT.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/Helpers/TestAsyncStreamReader.ofT.cs
@@ -1,0 +1,52 @@
+// Copied from and inspired by ASP.NET Core's TestAsyncStreamReader<T> class:
+// https://github.dev/dotnet/AspNetCore.Docs/tree/main/aspnetcore/grpc/test-services/sample
+
+using System.Threading.Channels;
+
+using Grpc.Core;
+
+namespace Aspire.ResourceService.Standalone.Server.Tests.Helpers;
+
+public class TestAsyncStreamReader<T> : IAsyncStreamReader<T> where T : class
+{
+    private readonly Channel<T> _channel;
+    private readonly ServerCallContext _serverCallContext;
+
+    public T Current { get; private set; } = null!;
+
+    public TestAsyncStreamReader(ServerCallContext serverCallContext)
+    {
+        _channel = Channel.CreateUnbounded<T>();
+        _serverCallContext = serverCallContext;
+    }
+
+    public void AddMessage(T message)
+    {
+        if (!_channel.Writer.TryWrite(message))
+        {
+            throw new InvalidOperationException("Unable to write message.");
+        }
+    }
+
+    public void Complete()
+    {
+        _channel.Writer.Complete();
+    }
+
+    public async Task<bool> MoveNext(CancellationToken cancellationToken)
+    {
+        _serverCallContext.CancellationToken.ThrowIfCancellationRequested();
+
+        if (await _channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false) &&
+            _channel.Reader.TryRead(out var message))
+        {
+            Current = message;
+            return true;
+        }
+        else
+        {
+            Current = null!;
+            return false;
+        }
+    }
+}

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/Helpers/TestServerCallContext.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/Helpers/TestServerCallContext.cs
@@ -1,0 +1,61 @@
+// Copied from and inspired by ASP.NET Core's TestAsyncStreamReader<T> class:
+// https://github.dev/dotnet/AspNetCore.Docs/tree/main/aspnetcore/grpc/test-services/sample
+
+using Grpc.Core;
+
+namespace Aspire.ResourceService.Standalone.Server.Tests.Helpers;
+
+public class TestServerCallContext : ServerCallContext
+{
+    private readonly Metadata _requestHeaders;
+    private readonly CancellationToken _cancellationToken;
+    private readonly Metadata _responseTrailers;
+    private readonly AuthContext _authContext;
+    private readonly Dictionary<object, object> _userState;
+    private WriteOptions? _writeOptions;
+
+    public Metadata? ResponseHeaders { get; private set; }
+
+    private TestServerCallContext(Metadata requestHeaders, CancellationToken cancellationToken)
+    {
+        _requestHeaders = requestHeaders;
+        _cancellationToken = cancellationToken;
+        _responseTrailers = [];
+        _authContext = new AuthContext(string.Empty, []);
+        _userState = [];
+    }
+
+    protected override string MethodCore => "MethodName";
+    protected override string HostCore => "HostName";
+    protected override string PeerCore => "PeerName";
+    protected override DateTime DeadlineCore { get; }
+    protected override Metadata RequestHeadersCore => _requestHeaders;
+    protected override CancellationToken CancellationTokenCore => _cancellationToken;
+    protected override Metadata ResponseTrailersCore => _responseTrailers;
+    protected override Status StatusCore { get; set; }
+    protected override WriteOptions? WriteOptionsCore { get => _writeOptions; set { _writeOptions = value; } }
+    protected override AuthContext AuthContextCore => _authContext;
+
+    protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions? options)
+    {
+        throw new NotImplementedException();
+    }
+
+    protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders)
+    {
+        if (ResponseHeaders != null)
+        {
+            throw new InvalidOperationException("Response headers have already been written.");
+        }
+
+        ResponseHeaders = responseHeaders;
+        return Task.CompletedTask;
+    }
+
+    protected override IDictionary<object, object> UserStateCore => _userState;
+
+    public static TestServerCallContext Create(Metadata? requestHeaders = null, CancellationToken cancellationToken = default)
+    {
+        return new TestServerCallContext(requestHeaders ?? [], cancellationToken);
+    }
+}

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/Helpers/TestServerStreamWriter.ofT.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/Helpers/TestServerStreamWriter.ofT.cs
@@ -1,0 +1,61 @@
+// Copied from and inspired by ASP.NET Core's TestAsyncStreamReader<T> class:
+// https://github.dev/dotnet/AspNetCore.Docs/tree/main/aspnetcore/grpc/test-services/sample
+
+using System.Threading.Channels;
+
+using Grpc.Core;
+
+namespace Aspire.ResourceService.Standalone.Server.Tests.Helpers;
+
+public class TestServerStreamWriter<T> : IServerStreamWriter<T> where T : class
+{
+    private readonly ServerCallContext _serverCallContext;
+    private readonly Channel<T> _channel;
+
+    public WriteOptions? WriteOptions { get; set; }
+
+    public TestServerStreamWriter(ServerCallContext serverCallContext)
+    {
+        _channel = Channel.CreateUnbounded<T>();
+
+        _serverCallContext = serverCallContext;
+    }
+
+    public void Complete()
+    {
+        _channel.Writer.Complete();
+    }
+
+    public IAsyncEnumerable<T> ReadAllAsync()
+    {
+        return _channel.Reader.ReadAllAsync();
+    }
+
+    public async Task<T?> ReadNextAsync()
+    {
+        if (await _channel.Reader.WaitToReadAsync().ConfigureAwait(false))
+        {
+            _channel.Reader.TryRead(out var message);
+            return message;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    public Task WriteAsync(T message)
+    {
+        if (_serverCallContext.CancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(_serverCallContext.CancellationToken);
+        }
+
+        if (!_channel.Writer.TryWrite(message))
+        {
+            throw new InvalidOperationException("Unable to write message.");
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/DockerResourceProviderTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/DockerResourceProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using Aspire.ResourceService.Standalone.Server.ResourceProviders;
+using Aspire.ResourceService.Standalone.Server.ResourceProviders;
 
 using Docker.DotNet;
 using Docker.DotNet.Models;
@@ -40,7 +40,7 @@ public class DockerResourceProviderTests : IDisposable
             .ReturnsAsync(containers);
 
         // Act
-        var resources = await _dockerResourceProvider.GetResourcesAsync();
+        var resources = await _dockerResourceProvider.GetResourcesAsync().ConfigureAwait(false);
 
         // Assert
         resources.Should().HaveCount(1);
@@ -73,13 +73,12 @@ public class DockerResourceProviderTests : IDisposable
         // Act
         for (var i = 0; i < 10; i++)
         {
-            _ = await _dockerResourceProvider.GetResourcesAsync();
+            _ = await _dockerResourceProvider.GetResourcesAsync().ConfigureAwait(false);
         }
 
         // Assert
         _dockerClientMock.Verify(c => c.Containers.ListContainersAsync(It.IsAny<ContainersListParameters>(), It.IsAny<CancellationToken>()), Times.Once);
     }
-
 
     [Fact]
     public async Task GerResourceLogsShouldReturnLogs()
@@ -130,7 +129,6 @@ public class DockerResourceProviderTests : IDisposable
             // cts.Task is cancelled mimicking the end of the log stream.
             // Swallow
         }
-
 
         // Assert
         resultLogs.Should().BeEquivalentTo(logs);

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/DockerResourceProviderTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/DockerResourceProviderTests.cs
@@ -40,7 +40,7 @@ public class DockerResourceProviderTests : IDisposable
             .ReturnsAsync(containers);
 
         // Act
-        var resources = await _dockerResourceProvider.GetResourcesAsync().ConfigureAwait(false);
+        var resources = await _dockerResourceProvider.GetResourcesAsync();
 
         // Assert
         resources.Should().HaveCount(1);
@@ -73,7 +73,7 @@ public class DockerResourceProviderTests : IDisposable
         // Act
         for (var i = 0; i < 10; i++)
         {
-            _ = await _dockerResourceProvider.GetResourcesAsync().ConfigureAwait(false);
+            _ = await _dockerResourceProvider.GetResourcesAsync();
         }
 
         // Assert

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/ServiceCollectionExtensionsTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/ResourceProvider/ServiceCollectionExtensionsTests.cs
@@ -1,11 +1,10 @@
-﻿using Aspire.ResourceService.Standalone.Server.ResourceProviders;
+using Aspire.ResourceService.Standalone.Server.ResourceProviders;
 
 using Docker.DotNet;
 
 using FluentAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
-
 
 namespace Aspire.ResourceService.Standalone.Server.Tests.ResourceProvider;
 


### PR DESCRIPTION
- **Update .editorconfig**
  Swap editorconfig with the one in the root of the
  [.NET Aspir](https://github.com/dotnet/aspire/blob/main/.editorconfig)
  

- **Update .editorconfig**
  Remove the file header section that was intended for .NET projects.
  

- **Format code using the new .editorconfig**
  The new editorconfig file enforces number of empty lines and the usage
  of `.ConfigureAwait(false)` everywhere on the project.
  

- **Remove spelling exclusion from .editorconfig**
  

- **chore: format .editorconfig file**
  

- **Reformat code using the new editorconfig**
  