### PR TITLE
fix/method name

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,6 @@
 
     <Description>A standalone resouce server for .NET Aspire</Description>
 
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
   </PropertyGroup>
 </Project>

--- a/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
@@ -5,7 +5,6 @@ using Aspire.Dashboard.Model;
 using Aspire.ResourceService.Proto.V1;
 using Docker.DotNet;
 using Docker.DotNet.Models;
-using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.ResourceService.Standalone.Server.ResourceProviders;
 

--- a/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/DockerResourceProvider.cs
@@ -19,7 +19,7 @@ internal sealed partial class DockerResourceProvider(IDockerClient dockerClient,
 
         return new ResourceSubscription(resources, UpdateStream(cancellationToken));
 
-        async IAsyncEnumerable<WatchResourcesChange> UpdateStream(
+        async IAsyncEnumerable<WatchResourcesChange?> UpdateStream(
             [EnumeratorCancellation] CancellationToken cancellation)
         {
             var channel = Channel.CreateUnbounded<Message>();
@@ -51,13 +51,21 @@ internal sealed partial class DockerResourceProvider(IDockerClient dockerClient,
         }
     }
 
-    private async Task<WatchResourcesChange> GetChangeForStartedContainer(string containerId)
+    private async Task<WatchResourcesChange?> GetChangeForStartedContainer(string containerId)
     {
-        var containers = await GetContainers().ConfigureAwait(false);
-        var container = containers.Single(c => string.Equals(c.ID, containerId, StringComparison.OrdinalIgnoreCase));
-        var resource = Resource.FromContainer(container);
+        try
+        {
+            var containers = await GetContainers().ConfigureAwait(false);
+            var container =
+                containers.Single(c => string.Equals(c.ID, containerId, StringComparison.OrdinalIgnoreCase));
+            var resource = Resource.FromContainer(container);
 
-        return new() { Upsert = resource };
+            return new() { Upsert = resource };
+        }
+        catch (Exception)
+        {
+            return null;
+        }
     }
 
     public async IAsyncEnumerable<string> GerResourceLogs(string resourceName,

--- a/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/IResourceProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/IResourceProvider.cs
@@ -10,4 +10,4 @@ public interface IResourceProvider
 
 public sealed record class ResourceSubscription(
     IReadOnlyList<Resource> InitialData,
-    IAsyncEnumerable<WatchResourcesChange> ChangeStream);
+    IAsyncEnumerable<WatchResourcesChange?> ChangeStream);

--- a/src/Aspire.ResourceService.Standalone.Server/appsettings.Development.json
+++ b/src/Aspire.ResourceService.Standalone.Server/appsettings.Development.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.ResourceService.Standalone.Server.ResourceProviders.DockerResourceProvider": "Trace"
     }
   }
 }

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
@@ -13,7 +13,7 @@ public sealed class ServiceInformationTests
     {
         IServiceInformationProvider sut = new AssemblyServiceInformationProvider();
 
-        sut.GetServiceInformation().Version.Should().Be("0.3.0");
+        sut.GetServiceInformation().Version.Should().Be("0.3.1");
         sut.GetServiceInformation().Name.Should().Be("Aspire.ResourceService.Standalone.Server");
     }
 


### PR DESCRIPTION
- **chore: Remove unused using statement**
  

- **Add guard agains errors on resource change**
  If a container resource is changed there is a chance that the `Single`
  LINQ method throws, this commit fixes it by returning null and omitting
  the null returned value in the gRPC service.
  