### PR TITLE
Refactor log handling to use ResourceLogEntry

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,6 @@
 
     <Description>A standalone resouce server for .NET Aspire</Description>
 
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
   </PropertyGroup>
 </Project>

--- a/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/IResourceProvider.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/IResourceProvider.cs
@@ -4,10 +4,21 @@ namespace Aspire.ResourceService.Standalone.Server.ResourceProviders;
 
 public interface IResourceProvider
 {
-    IAsyncEnumerable<string> GerResourceLogs(string resourceName, CancellationToken cancellationToken);
+    IAsyncEnumerable<ResourceLogEntry> GerResourceLogs(string resourceName, CancellationToken cancellationToken);
     Task<ResourceSubscription> GetResources(CancellationToken cancellationToken);
 }
 
 public sealed record class ResourceSubscription(
     IReadOnlyList<Resource> InitialData,
     IAsyncEnumerable<WatchResourcesChange?> ChangeStream);
+
+public readonly struct ResourceLogEntry
+{
+    public ResourceLogEntry(string resourceName, string line)
+    {
+        Line = line;
+        LogType = resourceName;
+    }
+    public string Line { get; }
+    public string LogType { get; }
+}

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/DashboardService/DashboardServiceTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/DashboardService/DashboardServiceTests.cs
@@ -90,7 +90,7 @@ public class DashboardServiceTests
     public async Task WatchResourcesLogs()
     {
         // Arrange
-        var logs = new List<string> { "Log1", "Log2" };
+        var logs = new List<ResourceLogEntry> { new("resource", "log-1"), new("resource", "log-2") };
         _mockResourceProvider
             .Setup(x => x.GerResourceLogs(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(logs.ToAsyncEnumerable());
@@ -113,8 +113,8 @@ public class DashboardServiceTests
         var update = await responseStream.ReadNextAsync().ConfigureAwait(true);
         update.Should().NotBeNull();
         update!.LogLines.Should().HaveCount(2);
-        update.LogLines[0].Text.Should().Be(logs[0]);
-        update.LogLines[1].Text.Should().Be(logs[1]);
+        update.LogLines[0].Text.Should().Be(logs[0].Line);
+        update.LogLines[1].Text.Should().Be(logs[1].Line);
     }
 
 }

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/Diagnostics/ServiceInformationTests.cs
@@ -13,7 +13,7 @@ public sealed class ServiceInformationTests
     {
         IServiceInformationProvider sut = new AssemblyServiceInformationProvider();
 
-        sut.GetServiceInformation().Version.Should().Be("0.3.1");
+        sut.GetServiceInformation().Version.Should().Be("0.3.2");
         sut.GetServiceInformation().Name.Should().Be("Aspire.ResourceService.Standalone.Server");
     }
 


### PR DESCRIPTION
- Updated `GerResourceLogs` method in `DockerResourceProvider` to return
  `IAsyncEnumerable<ResourceLogEntry>`.
- Modified `IResourceProvider` interface to reflect the new return type.
- Introduced `ResourceLogEntry` struct to encapsulate log lines and resource names.
- Adjusted `WatchResourceConsoleLogs` in `DashboardService` to process
  `ResourceLogEntry`.
- Updated tests in `DashboardServiceTests` to accommodate new log handling.
- Renamed and modified `GerResourceLogsShouldReturnLogs` test in
  `DockerResourceProviderTests` to `GetResourceLogsShouldReturnLogs`.
- Added additional test cases for `GetResourceLogs` method to verify
  cancellation token handling and log output.
