### PR TITLE
chore/watch resource state tests

### DIFF
--- a/src/Aspire.ResourceService.Standalone.Server/Services/DashboardService.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/Services/DashboardService.cs
@@ -132,8 +132,7 @@ internal static partial class WatchResourcesLogs
     [LoggerMessage(LogLevel.Trace, "Returning application information")]
     public static partial void ReturningApplicationInformation(this ILogger logger);
 
-    [LoggerMessage(Events.PreparingToGetResources, LogLevel.Trace,
-        "Preparing to get resources from the resource provider")]
+    [LoggerMessage(Events.PreparingToGetResources, LogLevel.Trace, "Preparing to get resources from the resource provider")]
     public static partial void GettingResourcesFromResourceProvider(this ILogger logger);
 
     [LoggerMessage(Events.ResourcesReceived, LogLevel.Trace, "Received {Count} resources from resource provider")]

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/DashboardService/ApplicationInformationTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/DashboardService/ApplicationInformationTests.cs
@@ -1,0 +1,54 @@
+using Aspire.ResourceService.Proto.V1;
+using Aspire.ResourceService.Standalone.Server.Diagnostics;
+using Aspire.ResourceService.Standalone.Server.ResourceProviders;
+using Aspire.ResourceService.Standalone.Server.Tests.Helpers;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using DashboardServiceImpl = Aspire.ResourceService.Standalone.Server.Services.DashboardService;
+
+namespace Aspire.ResourceService.Standalone.Server.Tests.DashboardService;
+
+public class ApplicationInformationTests
+{
+    private readonly Mock<IServiceInformationProvider> _mockServiceInformationProvider;
+    private readonly Mock<IResourceProvider> _mockResourceProvider;
+    private readonly Mock<IHostApplicationLifetime> _mockHostApplicationLifetime;
+    private readonly DashboardServiceImpl _dashboardService;
+
+    public ApplicationInformationTests()
+    {
+        _mockServiceInformationProvider = new Mock<IServiceInformationProvider>();
+        _mockResourceProvider = new Mock<IResourceProvider>();
+        _mockHostApplicationLifetime = new Mock<IHostApplicationLifetime>();
+        _dashboardService = new DashboardServiceImpl(
+            _mockServiceInformationProvider.Object,
+            _mockResourceProvider.Object,
+            _mockHostApplicationLifetime.Object,
+            NullLogger<DashboardServiceImpl>.Instance);
+    }
+
+    [Fact]
+    public async Task GetApplicationInformationTest()
+    {
+        // Arrange
+        var expectedName = Constants.ServiceName;
+        _mockServiceInformationProvider
+            .Setup(x => x.GetServiceInformation())
+            .Returns(new ServiceInformation { Name = expectedName });
+
+        var request = new ApplicationInformationRequest();
+        var context = TestServerCallContext.Create();
+
+        // Act
+        var response = await _dashboardService.GetApplicationInformation(request, context).ConfigureAwait(true);
+
+        // Assert
+        response.ApplicationName.Should().Be(expectedName);
+    }
+}

--- a/tests/Aspire.ResourceService.Standalone.Server.Tests/DashboardService/WatchResourceLogsTests.cs
+++ b/tests/Aspire.ResourceService.Standalone.Server.Tests/DashboardService/WatchResourceLogsTests.cs
@@ -1,0 +1,68 @@
+using Aspire.ResourceService.Proto.V1;
+using Aspire.ResourceService.Standalone.Server.Diagnostics;
+using Aspire.ResourceService.Standalone.Server.ResourceProviders;
+using Aspire.ResourceService.Standalone.Server.Tests.Helpers;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using DashboardServiceImpl = Aspire.ResourceService.Standalone.Server.Services.DashboardService;
+
+namespace Aspire.ResourceService.Standalone.Server.Tests.DashboardService;
+
+public class WatchResourceLogsTests
+{
+    private readonly Mock<IServiceInformationProvider> _mockServiceInformationProvider;
+    private readonly Mock<IResourceProvider> _mockResourceProvider;
+    private readonly Mock<IHostApplicationLifetime> _mockHostApplicationLifetime;
+    private readonly DashboardServiceImpl _dashboardService;
+
+    public WatchResourceLogsTests()
+    {
+        _mockServiceInformationProvider = new Mock<IServiceInformationProvider>();
+        _mockResourceProvider = new Mock<IResourceProvider>();
+        _mockHostApplicationLifetime = new Mock<IHostApplicationLifetime>();
+        _dashboardService = new DashboardServiceImpl(
+            _mockServiceInformationProvider.Object,
+            _mockResourceProvider.Object,
+            _mockHostApplicationLifetime.Object,
+            NullLogger<DashboardServiceImpl>.Instance);
+    }
+
+    [Fact]
+    public async Task WatchResourcesLogs()
+    {
+        // Arrange
+        var logs = new List<ResourceLogEntry> { new("resource", "log-1"), new("resource", "log-2") };
+        _mockResourceProvider
+            .Setup(x => x.GerResourceLogs(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(logs.ToAsyncEnumerable());
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        var callContext = TestServerCallContext.Create(cancellationToken: cts.Token);
+        var responseStream = new TestServerStreamWriter<WatchResourceConsoleLogsUpdate>(callContext);
+
+        var request = new WatchResourceConsoleLogsRequest { ResourceName = "resource" };
+
+        // Act
+        var call = _dashboardService.WatchResourceConsoleLogs(request, responseStream, callContext);
+
+        call.IsCompleted.Should().BeTrue();
+        await call.ConfigureAwait(true);
+
+        responseStream.Complete();
+
+        // Assert
+        var update = await responseStream.ReadNextAsync().ConfigureAwait(true);
+        update.Should().NotBeNull();
+        update!.LogLines.Should().HaveCount(2);
+        update.LogLines[0].Text.Should().Be(logs[0].Line);
+        update.LogLines[1].Text.Should().Be(logs[1].Line);
+    }
+
+}
+


### PR DESCRIPTION
- **chore: Format code**
  Ommit the two-line logger message attribute
  

- **Add tests for application info and resource updates**
  Created `ApplicationInformationTests` and `WatchResourceLogsTests` to
  validate the `DashboardService` methods.
  
  Renamed `DashboardServiceTests` to `WatchResourcesTests` and updated
  tests to focus on resource updates, including handling empty updates.
  
  Refactored to use `WatchResourcesUpdate` for improved clarity and
  functionality.
  

- **Add test for initial data with update stream behavior**
  Implemented `InitialSourceDataWithNonEmptyUpdateStream` in
  `WatchResourcesTests` to verify that the first message contains
  initial data and no changes, while subsequent messages only
  contain changes. Updated `MockResourceSubscription` to simulate
  multiple resource updates and added comments for clarity.
  

- **chore: code cleanup**
  Cleanup the test codes around watching resources states
  