### PR TITLE
fix/implement url display properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,6 @@
 
     <Description>A standalone resouce server for .NET Aspire</Description>
 
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
   </PropertyGroup>
 </Project>

--- a/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/Utils/Partials.cs
+++ b/src/Aspire.ResourceService.Standalone.Server/ResourceProviders/Utils/Partials.cs
@@ -25,8 +25,13 @@ public sealed partial class Resource
             .Select(s => new Url
             {
                 IsInternal = false,
-                Name = $"http://{s.IP}:{s.PublicPort}",
-                FullUrl = $"http://{s.IP}:{s.PublicPort}"
+                EndpointName = $"http://{s.IP}:{s.PublicPort}",
+                FullUrl = $"http://{s.IP}:{s.PublicPort}",
+                DisplayProperties = new()
+                {
+                    SortOrder = 0,
+                    DisplayName = ""
+                }
             }));
         return resource;
     }
@@ -44,8 +49,13 @@ public sealed partial class Resource
         resource.Urls.Add(new Url()
         {
             IsInternal = false,
-            Name = $"http://{container.Name}:{container.Port}",
-            FullUrl = $"http://{container.Name}:{container.Port}"
+            EndpointName = $"http://{container.Name}:{container.Port}",
+            FullUrl = $"http://{container.Name}:{container.Port}",
+            DisplayProperties = new()
+            {
+                SortOrder = 0,
+                DisplayName = ""
+            }
         });
         return resource;
     }

--- a/src/Aspire.ResourceService.Standalone.Server/appsettings.json
+++ b/src/Aspire.ResourceService.Standalone.Server/appsettings.json
@@ -11,7 +11,7 @@
       "Protocols": "Http2"
     }
   },
-  "ResourceProvider": "k8s",
+  "ResourceProvider": "docker",
   "KubernetesResourceProviderConfiguration": {
     "Namespace": "test",
     "Servicenames": "redis;rabbitmq"

--- a/src/proto/resource_service.proto
+++ b/src/proto/resource_service.proto
@@ -101,12 +101,24 @@ message EnvironmentVariable {
 
 message Url {
   // The name of the url
-  string name = 1;
+  optional string endpoint_name = 1;
   // The uri of the url. Format is scheme://host:port/{*path}
   string full_url = 2;
   // Determines if this url shows up in the details view only by default.
   // If true, the url will not be shown in the list of urls in the top level resources view.
   bool is_internal = 3;
+  // Indicates if this URL is inactive. A non-running resource may still return inactive URLs.
+  // If true, the inactive url will not be shown in the dashboard.
+  bool is_inactive = 4;
+  // Display properties of the Url
+  UrlDisplayProperties display_properties = 5;
+}
+
+message UrlDisplayProperties {
+  // The sort order of the url. Lower values are displayed first in the UI. The absence of a value is treated as lowest order.
+  int32 sort_order = 1;
+  // The display name of the url, to appear in the UI.
+  string display_name = 2;
 }
 
 message ResourceProperty {


### PR DESCRIPTION
Hi Kia, hope you and your family are well with everything going on.

I've taken a look at #42 and implemented the changes which were made in the Aspire `9.2.0` version to the protos. It's minimalistic, and currently just sets the display URL in the Aspire dashboard to blank, which Aspire then ignores and sets to the default URL (service url and port), so it can probably be improved upon in the future, but for now this works to get it up and running again.